### PR TITLE
Make this work vs. Terraform 0.12.26

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Example solution for :egg: vs :chicken: problem - how to create infrastructure f
 
 ## Assumptions
 
-* [Terraform](https://www.terraform.io/) installed (approach tested against `v0.11.2`)
+* [Terraform](https://www.terraform.io/) installed (approach tested against `v0.12.9`)
 * [AWS S3 backend](https://www.terraform.io/docs/backends/types/s3.html) with DynamoDB table for locking will be used
 * operator should have [AWS credentials in profile](https://docs.aws.amazon.com/cli/latest/userguide/cli-multiple-profiles.html) - for the purpose of this repo we use `terraform` profile
 * backend will be created and maintained under `base` workspace
@@ -22,7 +22,6 @@ When you run `setup.sh` the script will create required S3 bucket and DynamoDB t
 ## Problems not solved
 
 * AWS S3 policies doesn't support groups so each operator must be added explicit to the policy file
-* `-backend=false` doesn't work, so "hack" with separated `setup` directory must be used to run Terraform without S3 backend
 
 ## Questions and/or suggestions
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Example solution for :egg: vs :chicken: problem - how to create infrastructure f
 
 ## Assumptions
 
-* [Terraform](https://www.terraform.io/) installed (approach tested against `v0.12.9`)
+* [Terraform](https://www.terraform.io/) installed (approach tested against `v0.12.24`)
 * [AWS S3 backend](https://www.terraform.io/docs/backends/types/s3.html) with DynamoDB table for locking will be used
 * operator should have [AWS credentials in profile](https://docs.aws.amazon.com/cli/latest/userguide/cli-multiple-profiles.html) - for the purpose of this repo we use `terraform` profile
 * backend will be created and maintained under `base` workspace

--- a/backend.tfvars
+++ b/backend.tfvars
@@ -1,4 +1,4 @@
-bucket = "my-terraform-bucket"
+bucket = "my-terraform-bucket" # Needs to be globally unique
 dynamodb_table = "TerraformStatelock"
 key = "terraform.tfstate"
 profile = "terraform"

--- a/modules/backend/main.tf
+++ b/modules/backend/main.tf
@@ -1,12 +1,11 @@
 # KMS Key
 
 resource "aws_kms_key" "tf_enc_key" {
-  count = "${var.bootstrap}"
 
   description             = "Global Terraform state encryption key"
   deletion_window_in_days = 30
 
-  tags {
+  tags = {
     Origin = "Terraform"
   }
 }
@@ -14,7 +13,6 @@ resource "aws_kms_key" "tf_enc_key" {
 # S3 Bucket
 
 resource "aws_s3_bucket" "terraform_state" {
-  count = "${var.bootstrap}"
 
   bucket = "${var.bucket}"
   acl    = "private"
@@ -58,7 +56,7 @@ data "template_file" "operator_arn" {
   count    = "${length(var.operators)}"
   template = "\"$${arn}\""
 
-  vars {
+  vars = {
     arn = "${element(data.aws_iam_user.operators.*.arn, count.index)}"
   }
 }
@@ -66,7 +64,7 @@ data "template_file" "operator_arn" {
 data "template_file" "terraform_state_policy" {
   template = "${file("${path.module}/templates/policy.json.tpl")}"
 
-  vars {
+  vars = {
     bucket    = "${aws_s3_bucket.terraform_state.arn}"
     key       = "${var.key}"
     operators = "${join(",", data.template_file.operator_arn.*.rendered)}"
@@ -74,7 +72,6 @@ data "template_file" "terraform_state_policy" {
 }
 
 resource "aws_s3_bucket_policy" "terraform_state" {
-  count = "${var.bootstrap}"
 
   bucket = "${aws_s3_bucket.terraform_state.id}"
   policy = "${data.template_file.terraform_state_policy.rendered}"
@@ -95,7 +92,7 @@ resource "aws_dynamodb_table" "terraform_statelock" {
     type = "S"
   }
 
-  tags {
+  tags = {
     Origin = "Terraform"
   }
 }

--- a/modules/backend/main.tf
+++ b/modules/backend/main.tf
@@ -75,6 +75,7 @@ resource "aws_s3_bucket_policy" "terraform_state" {
 
   bucket = aws_s3_bucket.terraform_state.id
   policy = data.template_file.terraform_state_policy.rendered
+  count = "${length(var.operators) > 0 ? 1 : 0 }"
 }
 
 # DynamoDB

--- a/modules/backend/variables.tf
+++ b/modules/backend/variables.tf
@@ -5,7 +5,7 @@ variable "bootstrap" {
 }
 
 variable "operators" {
-  type = "list"
+  type = list
 }
 
 variable "bucket" {}

--- a/setup/backend.tf
+++ b/setup/backend.tf
@@ -1,0 +1,4 @@
+# The recommendation now is to declare a "local" backend block instead of having no backend declared for the initial bootstrap.
+terraform {
+  backend "local" {}
+}

--- a/setup/main.tf
+++ b/setup/main.tf
@@ -1,6 +1,6 @@
 provider "aws" {
-  profile = "${var.profile}"
-  region  = "${var.region}"
+  profile = var.profile
+  region  = var.region
 }
 
 module "backend" {
@@ -8,7 +8,7 @@ module "backend" {
 
   bootstrap      = "${terraform.workspace == "base" ? 1 : 0}"
   operators      = "${local.operators}"
-  bucket         = "${var.bucket}"
-  dynamodb_table = "${var.dynamodb_table}"
-  key            = "${var.key}"
+  bucket         = var.bucket
+  dynamodb_table = var.dynamodb_table
+  key            = var.key
 }

--- a/setup/variables.tf
+++ b/setup/variables.tf
@@ -1,7 +1,6 @@
 locals {
   operators = [
-    "john.blacksmith",
-    "kate.snow"
+    # Put any local operator IAM user names here
   ]
 }
 


### PR DESCRIPTION
This pull request builds on @IanMoroney's excellent work.

This also removes all the deprecation warnings related to warn that Terraform 0.11-style quoted string interpolation.

It removes the default list of operators from the S3 bucket too - those are optional.